### PR TITLE
Add autoload comment

### DIFF
--- a/super-hint-rg.el
+++ b/super-hint-rg.el
@@ -74,10 +74,12 @@
   (add-to-list 'compilation-finish-functions #'super-hint--rg-hint-all nil))
 
 
+;;;###autoload
 (defun super-hint-enable-rg()
   (interactive)
   (add-hook 'rg-mode-hook #'super-hint-setup))
 
+;;;###autoload
 (defun super-hint-disable-rg()
   (interactive)
   (remove-hook 'rg-mode-hook #'super-hint-setup)

--- a/super-hint-xref.el
+++ b/super-hint-xref.el
@@ -44,10 +44,12 @@
   (super-hint--xref-hint-all))
 
 
+;;;###autoload
 (defun super-hint-enable-xref()
   (interactive)
   (add-hook 'xref-after-update-hook #'super-hint--xref-hint-after-update))
 
+;;;###autoload
 (defun super-hint-disable-xref()
   (interactive)
   (remove-hook 'xref-after-update-hook #'super-hint--xref-hint-after-update)


### PR DESCRIPTION
I added the autoload magic comment.

This is useful because it allows for the automatic generation of autoloads that delay require when installing packages with tools like use-package's `:vc` keyword in Emacs 30+, el-get, or Leaf's `:vc` keyword