### PR TITLE
Let `super-hint--xref-hint-all' work in any xref buffer

### DIFF
--- a/super-hint-xref.el
+++ b/super-hint-xref.el
@@ -27,12 +27,7 @@
 (defun super-hint--xref-hint-all()
   (interactive)
   (setq-local scroll-margin 1)
-  (when (memq this-command
-			  '(xref-find-references
-				xref-find-definition-or-reference
-				lsp-find-implementation
-				xref-revert-buffer
-				exec/lsp-toggle-filter-test))
+  (when (derived-mode-p 'xref--xref-buffer-mode)
 	(with-current-buffer (current-buffer)
 	  (goto-char (point-min))
 	  (while (not (eobp))


### PR DESCRIPTION
The current behavior of `super-hint-xref-hint-all`, which is the function that "does the work" of adding hints for xref buffers, is limited to doing that work if the invoked command is included in a list of pre-defined commands. I found this limiting, since other non-pre-defined commands might create an xref buffer. In my case, it was `embark-consult-export-grep` (from the embark-consult package; I can call `embark-export` in a `consult-xref` query to export those results into a grep buffer).

This PR changes `super-hint-xref-hint-all` to work instead in any buffer whose major mode is `xref--xref-buffer-mode`, the major mode xref uses.

(I apologize for toggling the draft state of the PR so many times! I thought it wasn't working on my end but it was.)