### PR TITLE
Use minor modes instead of enable/disable commands

### DIFF
--- a/README.org
+++ b/README.org
@@ -22,9 +22,7 @@ Note: super-hint.el need https://github.com/dajva/rg.el
 
     (require 'rg)
     (require 'super-hint-rg)
-    (super-hint-enable-rg) ;; then M-x rg-project to enjoy super-hint
-
-    ;; (super-hint-disable-rg)
+    (super-hint-rg-mode 1) ;; then M-x rg-project to enjoy super-hint
 
     (require 'super-hint-xref)
     (super-hint-enable-xref) ;; then M-x xref-find-references to enjoy super-hint

--- a/README.org
+++ b/README.org
@@ -25,9 +25,8 @@ Note: super-hint.el need https://github.com/dajva/rg.el
     (super-hint-rg-mode 1) ;; then M-x rg-project to enjoy super-hint
 
     (require 'super-hint-xref)
-    (super-hint-enable-xref) ;; then M-x xref-find-references to enjoy super-hint
+    (super-hint-xref-mode 1) ;; then M-x xref-find-references to enjoy super-hint
 
-    ;; (super-hint-disable-xref)
     ;; (which-function-mode t) ;; enable which-function mode if you not
     )
 

--- a/super-hint-rg.el
+++ b/super-hint-rg.el
@@ -3,6 +3,11 @@
 (require 'super-hint)
 (require 'rg)
 
+(defcustom super-hint-rg-lighter " SH-RG"
+  "The minor mode lighter for `super-hint-rg-mode'."
+  :type 'string
+  :group 'super-hint)
+
 (defun super-hint--shorten-string (str)
   (if (> (length str) super-hint-hint-width)
 	  (let ((start (substring str 0 10))
@@ -73,16 +78,13 @@
 (defun super-hint-setup(&rest args)
   (add-to-list 'compilation-finish-functions #'super-hint--rg-hint-all nil))
 
-
 ;;;###autoload
-(defun super-hint-enable-rg()
-  (interactive)
-  (add-hook 'rg-mode-hook #'super-hint-setup))
-
-;;;###autoload
-(defun super-hint-disable-rg()
-  (interactive)
-  (remove-hook 'rg-mode-hook #'super-hint-setup)
-  )
+(define-minor-mode super-hint-rg-mode
+  "Global minor mode to enable/disable `super-hint' in `rg' buffers."
+  :global t
+  :lighter super-hint-rg-lighter
+  (if super-hint-rg-mode
+      (add-hook 'rg-mode-hook #'super-hint-setup)
+    (remove-hook 'rg-mode-hook #'super-hint-setup)))
 
 (provide 'super-hint-rg)

--- a/super-hint-xref.el
+++ b/super-hint-xref.el
@@ -2,6 +2,11 @@
 
 (require 'xref)
 
+(defcustom super-hint-xref-lighter " SH-xref"
+  "The minor mode lighter for `super-hint-rg-mode'."
+  :type 'string
+  :group 'super-hint)
+
 (defun super-hint--xref-hint()
   (interactive)
   ;; get xref file  and line, set col as 0
@@ -38,16 +43,14 @@
 (defun super-hint--xref-hint-after-update()
   (super-hint--xref-hint-all))
 
-
 ;;;###autoload
-(defun super-hint-enable-xref()
-  (interactive)
-  (add-hook 'xref-after-update-hook #'super-hint--xref-hint-after-update))
+(define-minor-mode super-hint-xref-mode
+  "Global minor mode to enable/disable `super-hint' in `xref' buffers."
+  :global t
+  :lighter super-hint-xref-lighter
+  (if super-hint-xref-mode
+      (add-hook 'xref-after-update-hook #'super-hint--xref-hint-after-update)
+    (remove-hook 'xref-after-update-hook #'super-hint--xref-hint-after-update)))
 
-;;;###autoload
-(defun super-hint-disable-xref()
-  (interactive)
-  (remove-hook 'xref-after-update-hook #'super-hint--xref-hint-after-update)
-  )
 
 (provide 'super-hint-xref)


### PR DESCRIPTION
From my experience, if a package adds function(s) from a hook and removes function(s) from the same hook, it is more conventional to do this through minor mode instead of having a separate function for adding to the hook then another for removing from the hook.

As described in #8, this PR implements globalized minor modes `super-hint-rg-mode` and `super-hint-xref-mode` to replace the exisiting `super-hint-{enable,disable}-{xref,rg}`. Additionally, I define options for their mode line lighters: `super-hint-{xref,rg}-lighter`.