### PR TITLE
Require super-hint.el in super-hint-xref.el

### DIFF
--- a/super-hint-xref.el
+++ b/super-hint-xref.el
@@ -1,5 +1,6 @@
 ;; -*- lexical-binding: t; -*-
 
+(require 'super-hint)
 (require 'xref)
 
 (defcustom super-hint-xref-lighter " SH-xref"


### PR DESCRIPTION
Previously, loading `super-hint-xref' would not also load the functions and variables defined in `super-hint' necessary for its functionality.